### PR TITLE
Added an Id member to LibraryItem

### DIFF
--- a/ServerlessLibraryAPI/CacheService.cs
+++ b/ServerlessLibraryAPI/CacheService.cs
@@ -88,6 +88,10 @@ namespace ServerlessLibrary
                     {
                         foreach (LibraryItem libraryItem in libraryItems)
                         {
+                            int itemsCountInStore = this.libraryStore.Count();
+
+                            // Assign an Id which is a string form of integer to each item. Otherwise cosmosdb will assign a guid as id which is not user friendly.  
+                            libraryItem.Id = (itemsCountInStore + 1) + string.Empty;
                             this.libraryStore.Add(libraryItem);
                         }
                     }

--- a/ServerlessLibraryAPI/CosmosLibraryStore.cs
+++ b/ServerlessLibraryAPI/CosmosLibraryStore.cs
@@ -29,8 +29,13 @@ namespace ServerlessLibrary
 
         async public Task<IList<LibraryItem>> GetAllItems()
         {
-            IEnumerable<LibraryItem> libraryItems = await CosmosDBRepository<LibraryItem>.GetItemsAsync(i => i.Template != null);
+            IEnumerable<LibraryItem> libraryItems = await CosmosDBRepository<LibraryItem>.GetItemsAsync(i => i != null);
             return libraryItems.ToList();
+        }
+
+        public int Count()
+        {
+            return CosmosDBRepository<LibraryItem>.Count();
         }
     }
 
@@ -80,6 +85,11 @@ namespace ServerlessLibrary
             }
 
             return results;
+        }
+
+        public static int Count()
+        {
+            return client.CreateDocumentQuery(UriFactory.CreateDocumentCollectionUri(DatabaseId, CollectionId), new FeedOptions() { EnableCrossPartitionQuery = true }).Count();
         }
 
         public static async Task<Document> CreateItemAsync(T item)

--- a/ServerlessLibraryAPI/FileLibraryStore.cs
+++ b/ServerlessLibraryAPI/FileLibraryStore.cs
@@ -31,5 +31,10 @@ namespace ServerlessLibrary
             var fileContent = JsonConvert.DeserializeObject<List<LibraryItem>>(await System.IO.File.ReadAllTextAsync(file));
             return fileContent;
         }
+
+        public int Count()
+        {
+            throw new NotSupportedException();
+        }
     }
 }

--- a/ServerlessLibraryAPI/ILibraryStore.cs
+++ b/ServerlessLibraryAPI/ILibraryStore.cs
@@ -19,5 +19,11 @@ namespace ServerlessLibrary
         /// </summary>
         /// <returns></returns>
         Task<IList<LibraryItem>> GetAllItems();
+
+        /// <summary>
+        /// Get count of items in the library
+        /// </summary>
+        /// <returns>count of items</returns>
+        int Count();
     }
 }

--- a/ServerlessLibraryAPI/LibraryItem.cs
+++ b/ServerlessLibraryAPI/LibraryItem.cs
@@ -8,6 +8,9 @@ namespace ServerlessLibrary
 {
     public class LibraryItem
     {
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; set; }
+
         [JsonProperty(PropertyName = "title", DefaultValueHandling = DefaultValueHandling.Include)]
         public string Title { get; set; }
 


### PR DESCRIPTION
- Id of library item is is required in detailed view page for deep linking. By default cosmos db assigns a guid as id of documents, which is not user friendly.