### PR TITLE
Detail page stying

### DIFF
--- a/ServerlessLibraryAPI/ClientApp/src/components/DetailView/DetailPageContent.js
+++ b/ServerlessLibraryAPI/ClientApp/src/components/DetailView/DetailPageContent.js
@@ -91,7 +91,7 @@ class DetailPageContent extends Component {
         >
           <PivotItem headerText="Overview" itemKey="overview">
             <div className="pivot-item-container">
-              <div className="wrapper">
+              <div className="scrollablePane-wrapper">
                 <ScrollablePane>
                   <ReactMarkdown>{this.state.markdownText}</ReactMarkdown>
                 </ScrollablePane>
@@ -100,7 +100,7 @@ class DetailPageContent extends Component {
           </PivotItem>
           <PivotItem headerText="ARM template" itemKey="armtemplate">
             <div className="pivot-item-container">
-              <div className="wrapper">
+              <div className="scrollablePane-wrapper">
                 <ScrollablePane>
                   <div className="tab-summary">ARM template</div>
                   <div className="armtemplate-content">
@@ -112,7 +112,7 @@ class DetailPageContent extends Component {
           </PivotItem>
           <PivotItem headerText="Licence" itemKey="licence">
             <div className="pivot-item-container">
-              <div className="wrapper">
+              <div className="scrollablePane-wrapper">
                 <ScrollablePane>
                   <div className="tab-summary">Licence details</div>
                   <div className="licence-content">

--- a/ServerlessLibraryAPI/ClientApp/src/components/DetailView/DetailPageContent.js
+++ b/ServerlessLibraryAPI/ClientApp/src/components/DetailView/DetailPageContent.js
@@ -6,27 +6,7 @@ import {
   PivotLinkSize,
   ScrollablePane
 } from "office-ui-fabric-react/lib/index";
-import { getTheme, mergeStyleSets } from "office-ui-fabric-react";
 import "./DetailPageContent.scss";
-const theme = getTheme();
-
-const classNames = mergeStyleSets({
-  wrapper: {
-    minHeight: "60vh",
-    position: "relative",
-    maxHeight: "inherit"
-  },
-  pane: {
-    minHeight: "60vh",
-    border: "0px solid " + theme.palette.neutralLight,
-    whiteSpace: "pre",
-    backgroundColor: "#FBFBFB",
-    width: "80%"
-  },
-  textContent: {
-    padding: "15px 10px"
-  }
-});
 
 class DetailPageContent extends Component {
   constructor(props) {
@@ -93,29 +73,16 @@ class DetailPageContent extends Component {
     const pivotStyles = {
       root: {
         borderBottom: "1px solid rgba(105, 130, 155, 0.25)",
-        paddingLeft: "15px",
-        width: "80%"
+        paddingLeft: "15px"
       },
       text: {
         color: " #0058AD",
         fontSize: "14px"
-      },
-      link: {
-        color: "black"
-      },
-      linkIsSelected: {
-        selectors: {
-          ":before": {
-            color: "#161616",
-            boxSizing: "border-box",
-            borderBottom: "2px solid #161616"
-          }
-        }
       }
     };
 
     return (
-      <div>
+      <div className="detail-page-content">
         <Pivot
           styles={pivotStyles}
           selectedKey={this.state.selectedKey}
@@ -124,9 +91,8 @@ class DetailPageContent extends Component {
         >
           <PivotItem headerText="Overview" itemKey="overview">
             <div className="pivot-item-container">
-              <h4>Sample details</h4>
-              <div className={classNames.wrapper}>
-                <ScrollablePane styles={{ root: classNames.pane }}>
+              <div className="wrapper">
+                <ScrollablePane>
                   <ReactMarkdown>{this.state.markdownText}</ReactMarkdown>
                 </ScrollablePane>
               </div>
@@ -134,10 +100,10 @@ class DetailPageContent extends Component {
           </PivotItem>
           <PivotItem headerText="ARM template" itemKey="armtemplate">
             <div className="pivot-item-container">
-              <h4>ARM template</h4>
-              <div className={classNames.wrapper}>
-                <ScrollablePane styles={{ root: classNames.pane }}>
-                  <div className="container-content">
+              <div className="wrapper">
+                <ScrollablePane>
+                  <div className="tab-summary">ARM template</div>
+                  <div className="armtemplate-content">
                     {this.state.armTemplateText}
                   </div>
                 </ScrollablePane>
@@ -146,17 +112,20 @@ class DetailPageContent extends Component {
           </PivotItem>
           <PivotItem headerText="Licence" itemKey="licence">
             <div className="pivot-item-container">
-              <h4>Licence details</h4>
-              <div className={classNames.wrapper}>
-                <ScrollablePane styles={{ root: classNames.pane }}>
-                  <div className="container-content">
-                    Each application is licensed to you by its owner (which may
-                    or may not be Microsoft) under the agreement which
-                    accompanies the application. Microsoft is not responsible
-                    for any non-Microsoft code and does not screen for security,
-                    compatibility, or performance. The applications are not
-                    supported by any Microsoft support program or service. The
-                    applications are provided AS IS without warranty of any kind
+              <div className="wrapper">
+                <ScrollablePane>
+                  <div className="tab-summary">Licence details</div>
+                  <div className="licence-content">
+                    <p>
+                      Each application is licensed to you by its owner (which
+                      may or may not be Microsoft) under the agreement which
+                      accompanies the application. Microsoft is not responsible
+                      for any non-Microsoft code and does not screen for
+                      security, compatibility, or performance. The applications
+                      are not supported by any Microsoft support program or
+                      service. The applications are provided AS IS without
+                      warranty of any kind
+                    </p>
                     <p>
                       Also, please note that the Function App you've selected
                       was created with Azure Functions 1.x. As such, it might

--- a/ServerlessLibraryAPI/ClientApp/src/components/DetailView/DetailPageContent.scss
+++ b/ServerlessLibraryAPI/ClientApp/src/components/DetailView/DetailPageContent.scss
@@ -1,12 +1,29 @@
 .pivot-item-container {
-  margin-left: 23px;
-  width: 100%;
+  padding-left: 23px;
+  background-color: #fbfbfb;
+}
+.wrapper {
+  min-height: 60vh;
+  position: relative;
+  max-height: inherit;
 }
 
-.container-content {
+.tab-summary {
+  background: #ffffff;
+  padding-top: 17px;
+  padding-bottom: 13px;
+  font-size: 13px;
+  font-weight: bold;
+}
+
+.armtemplate-content {
   overflow-wrap: break-word;
   white-space: pre-line;
   justify-content: center;
-  overflow-x: hidden;
-  width: 100%;
+}
+
+.licence-content {
+  max-width: 750px;
+  text-align: justify;
+  text-justify: inter-word;
 }

--- a/ServerlessLibraryAPI/ClientApp/src/components/DetailView/DetailPageContent.scss
+++ b/ServerlessLibraryAPI/ClientApp/src/components/DetailView/DetailPageContent.scss
@@ -2,7 +2,7 @@
   padding-left: 23px;
   background-color: #fbfbfb;
 }
-.wrapper {
+.scrollablePane-wrapper {
   min-height: 60vh;
   position: relative;
   max-height: inherit;

--- a/ServerlessLibraryAPI/ClientApp/src/components/shared/PageHeaderWithBackButton.scss
+++ b/ServerlessLibraryAPI/ClientApp/src/components/shared/PageHeaderWithBackButton.scss
@@ -1,8 +1,8 @@
 .page-header {
-  margin-top: 20px;
+  padding-top: 20px;
   // margin-bottom: 23px; // this cannot be set at the common header control because of pivot control sizes
   background: #ffffff;
-  margin-left: 23px;
+  padding-left: 23px;
 }
 .page-title-container {
   display: flex;


### PR DESCRIPTION
- Made sure scrollbar does not appear on detail page.
- Licence content is justified and max width is set to 750 px.
- Tab pane upper border line is now 100% width