### PR TITLE
Adding github dev button

### DIFF
--- a/ServerlessLibraryAPI/ClientApp/src/components/DetailView/ActionBar.js
+++ b/ServerlessLibraryAPI/ClientApp/src/components/DetailView/ActionBar.js
@@ -44,9 +44,22 @@ class ActionBar extends Component {
     return "vscode://vscode.git/clone?url=" + encodeURIComponent(repository);
   }
 
+  getOpenInGithubDevLink(repository) {
+    if(repository){
+      return repository.replace("github\.com", "github\.dev");
+    } else {
+      return repository
+    }
+  }
+
   openInVSCodeClick() {
     this.updateDownloadCount(this.props.id);
     this.trackUserActionEvent("/sample/openinvscode");
+  }
+
+  openInGithubDevClick() {
+    this.updateDownloadCount(this.props.id);
+    this.trackUserActionEvent("/sample/openingithubdev");
   }
 
   trackUserActionEvent(eventName) {
@@ -73,6 +86,18 @@ class ActionBar extends Component {
             <div className="action-link-wrapper">
               <Icon iconName="Edit" className="fabric-icon-link" />
               <span className="action-link-text">Edit in VS Code</span>
+            </div>
+          </FabricLink>
+        </div>
+        <div className="action-item">
+          <FabricLink
+            href={this.getOpenInGithubDevLink(repository)}
+            disabled={!repository}
+            onClick={this.openInGithubDevClick}
+          >
+            <div className="action-link-wrapper">
+              <Icon iconName="Edit" className="fabric-icon-link" />
+              <span className="action-link-text">Edit in GitHub.dev</span>
             </div>
           </FabricLink>
         </div>


### PR DESCRIPTION
Adding github.dev link/button to be able open sample in github.dev editor.

![Demo](https://user-images.githubusercontent.com/5436734/134557315-8a272982-963b-4a78-b191-a445514cea4c.gif)


